### PR TITLE
replace deprecated "include:"  and always load mod_tls

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
   include_vars: "{{ ansible_os_family | lower }}.yml"
 
 - name: Include initial OS-specific tasks
-  include: "{{ ansible_os_family | lower}}.yml"
+  include_tasks: "{{ ansible_os_family | lower}}.yml"
 
 - name: Comment base proftpd.conf options
   lineinfile:
@@ -56,11 +56,11 @@
     - restart proftpd
 
 - name: Include tasks for TLS configuration
-  include: tls.yml
+  include_tasks: tls.yml
   when: proftpd_conf_ssl_certificate is defined and proftpd_conf_ssl_certificate_key is defined
 
 - name: Include tasks for Galaxy authentication
-  include: galaxy_auth.yml
+  include_tasks: galaxy_auth.yml
   when: proftpd_galaxy_auth is defined
 
 - name: Create VirtualHost configurations

--- a/templates/tls.conf.j2
+++ b/templates/tls.conf.j2
@@ -15,6 +15,7 @@ TLSSessionCache shm:/file={{ proftpd_tls_sesscache_path }}&size=8388608 {{ proft
 {% endif %}
 
 # Enable TLS
+LoadModule mod_tls.c
 TLSEngine on
 TLSLog {{ proftpd_log_dir | default('/var/log/proftpd') }}/tls.log
 


### PR DESCRIPTION
Two minor fixes in one:

- replace "include:" directives, deprecated in Ansible 2.4, with more favoured "include_tasks:"

- add loading mod_tls.c explicitly; when run with "proftpd_use_mod_tls_shmcache=false", the module was not loaded, yielding errors on startup; on the other hand, loading it unconditionally in tls.conf does not harm